### PR TITLE
fix: Reorder logic for module definition

### DIFF
--- a/cadence.js
+++ b/cadence.js
@@ -1,7 +1,7 @@
 ! function (definition) {
-    if (typeof window != "undefined") window.cadence = definition()
+    if (typeof module == 'object') module.exports = definition();
+    else if (typeof window != "undefined") window.cadence = definition()
     else if (typeof define == "function") define(definition)
-    else module.exports = definition()
 } (function () {
     // NOTE: You are allowed to say, "behavior is undefined." Cadence in its
     // current incarnation may behave a certain way, but you do not have to

--- a/redux.js
+++ b/redux.js
@@ -1,7 +1,7 @@
 ! function (definition) {
-    if (typeof window != "undefined") window.cadence = definition()
+    if (typeof module == 'object') module.exports = definition();
+    else if (typeof window != "undefined") window.cadence = definition()
     else if (typeof define == "function") define(definition)
-    else module.exports = definition()
 } (function () {
     var stack = [], push = [].push, token = {}
 

--- a/redux_.js
+++ b/redux_.js
@@ -1,7 +1,7 @@
 ! function (definition) {
-    if (typeof window != "undefined") window.cadence = definition()
+    if (typeof module == 'object') module.exports = definition();
+    else if (typeof window != "undefined") window.cadence = definition()
     else if (typeof define == "function") define(definition)
-    else module.exports = definition()
 } (function () {
     var stack = [], push = [].push, token = {}
 


### PR DESCRIPTION
This makes it so when compiled with browserify or anything like it the module is properly exported.