### PR TITLE
async.splat and async.hash

### DIFF
--- a/cadence.js
+++ b/cadence.js
@@ -232,6 +232,11 @@ function invoke (cadence) {
             }
         }
 
+        if (fn === async.splat) {
+          cadence.vargs = [vargs]
+          continue
+        }
+
         stack.push(cadence)
 
         var ret = call(fn, cadence.self, vargs)
@@ -393,5 +398,10 @@ async.map = variadic(function (steps) {
         return loop = this.apply(null, steps).apply(null, vargs)
     }, this)
 }, async)
+
+async.splat = variadic(function(steps) {
+  steps.push([]);
+  this.apply(null, steps);
+}, async);
 
 module.exports = cadence

--- a/cadence.js
+++ b/cadence.js
@@ -404,4 +404,15 @@ async.splat = variadic(function(steps) {
   this.apply(null, steps);
 }, async);
 
+async.hash = function(steps) {
+  async.forEach(function(key, index, memo) {
+    async(function() {
+      async(steps[key]);
+    }, function(res) {
+      memo[key] = res;
+      return [memo];
+    });
+  })(Object.keys(steps), {});
+};
+
 module.exports = cadence

--- a/t/cadence/hash.t.js
+++ b/t/cadence/hash.t.js
@@ -1,0 +1,34 @@
+require('proof')(1, prove);
+
+function prove (assert, callback) {
+    var cadence = require('../..');
+    cadence(function (async) {
+        async(function () {
+          async.hash({
+            // Single return value
+            single: function() {
+              return 1;
+            },
+
+            // Multiple return values (all but the first are ignored)
+            multiple: function() {
+              async()(null, 2);
+              async()(null, 3);
+            },
+
+            // Return an array to preserve multiple values
+            array: function() {
+              async(function() {
+                async()(null, 4);
+                async()(null, 5);
+              }, async.splat);
+            }
+          });
+        }, function (result) {
+        });
+    })(function (error, result) {
+        if (error) throw error;
+        assert(result, { single: 1, multiple: 2, array: [4, 5] }, 'hash');
+        callback();
+    });
+}

--- a/t/cadence/splat.t.js
+++ b/t/cadence/splat.t.js
@@ -1,0 +1,22 @@
+require('proof')(2, prove)
+
+function prove (assert, callback) {
+    var cadence = require('../..')
+    cadence(function (async) {
+        async(function () {
+          async()(null, 1);
+          async()(null, 2);
+          async()(null, 3);
+        }, async.splat, function (result) {
+            assert(result, [1, 2, 3], 'splat step')
+
+            async.splat(function() {
+              return [4, 5, 6];
+            });
+        });
+    })(function (error, result) {
+        if (error) throw error
+            assert(result, [4, 5, 6], 'splat function')
+        callback()
+    })
+}


### PR DESCRIPTION
This PR is a proof of concept for `async.splat` and `async.hash`. I'm totally open for discussion on their usefulness and alternate implementations.

## async.splat
Used in place of an empty array in order to gather multiple return values from a step into a single array to be passed to the next step. Not strictly needed (obviously `[]` is more succinct) but I think it is more explicit.

## async.hash
Inspired by Ember's [RSVP.hash](http://emberjs.com/api/classes/RSVP.html#method_hash), `async.hash` accepts an object where each value is a step, and returns an object with the first return value of each step as its values. I opted to ignore multiple return values as it seemed more useful than always returning an array or somehow trying to guess whether the user wanted a single value returned or a single-item array.